### PR TITLE
feat: actors (getActorList + getActor)

### DIFF
--- a/src/api/actor/effects/getActor.effect.spec.ts
+++ b/src/api/actor/effects/getActor.effect.spec.ts
@@ -1,0 +1,45 @@
+import * as request from 'supertest';
+import { app } from '../../../app';
+import { mockAuthorizationFor } from '../../../tests/auth.mock';
+import { mockActor } from '../../../tests/actor.mock';
+import { mockUser } from '../../../tests/user.mock';
+
+describe('getActor$', () => {
+  test('GET /api/v1/actor/:id returns 200 if actor is found', async () => {
+    const user = await mockUser();
+    const actors = [await mockActor(), await mockActor()];
+    const token = await mockAuthorizationFor(user)(app);
+    const targetActor = actors[0];
+
+    return request(app)
+      .get(`/api/v1/actor/${targetActor.imdbId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+      .then(({ body }) => {
+        expect(body._id).toEqual(String(targetActor._id));
+        expect(body.name).toEqual(targetActor.name);
+        expect(body.imdbId).toEqual(targetActor.imdbId);
+        expect(body.gender).toEqual(targetActor.gender);
+        expect(body.country).toEqual(targetActor.country);
+        expect(body.birthday).toEqual(targetActor.birthday);
+        expect(body.deathday).toEqual(targetActor.deathday);
+        expect(body.photoUrl).toEqual(targetActor.photoUrl);
+      });
+  });
+
+  test('GET /api/v1/actor returns empty array if no actors are found', async () => {
+    const user = await mockUser();
+    const token = await mockAuthorizationFor(user)(app);
+
+    return request(app)
+      .get('/api/v1/actor/not_exists')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(404, { error: { status: 404, message: 'Actor does not exist' } });
+  });
+
+  test('GET /api/v1/actor returns 401 if not authorized', async () =>
+    request(app)
+      .get('/api/v1/actor/123')
+      .expect(401, { error: { status: 401, message: 'Unauthorized' } })
+  );
+});

--- a/src/api/actor/effects/getActor.effect.ts
+++ b/src/api/actor/effects/getActor.effect.ts
@@ -1,0 +1,16 @@
+import { Effect, HttpError, HttpStatus } from '@marblejs/core';
+import { throwError } from 'rxjs';
+import { mergeMap, map, catchError } from 'rxjs/operators';
+import { ActorDao } from '../model/actor.dao';
+import { neverNullable } from '../../../util';
+
+export const getActorEffect$: Effect = req$ =>
+  req$.pipe(
+    map(req => req.params.id),
+    mergeMap(ActorDao.findOneByImdbID),
+    mergeMap(neverNullable),
+    map(actor => ({ body: actor })),
+    catchError(() => throwError(
+      new HttpError('Actor does not exist', HttpStatus.NOT_FOUND)
+    ))
+  );

--- a/src/api/actor/effects/getActorList.effect.spec.ts
+++ b/src/api/actor/effects/getActorList.effect.spec.ts
@@ -1,0 +1,46 @@
+import * as request from 'supertest';
+import { app } from '../../../app';
+import { mockAuthorizationFor } from '../../../tests/auth.mock';
+import { mockActor } from '../../../tests/actor.mock';
+import { mockUser } from '../../../tests/user.mock';
+
+describe('getActorList$', () => {
+  test('GET /api/v1/actor returns 200 and list of actors', async () => {
+    const actors = [await mockActor(), await mockActor(), await mockActor()];
+    const user = await mockUser();
+    const token = await mockAuthorizationFor(user)(app);
+
+    return request(app)
+      .get('/api/v1/actor')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200)
+      .then(({ body }) => {
+        actors.forEach((actor, i) => {
+          const result = body[i];
+          expect(result.imdbId).toEqual(String(actor.imdbId));
+          expect(result.name).toEqual(actor.name);
+          expect(result.birthday).toEqual(actor.birthday);
+          expect(result.deathday).toEqual(actor.deathday);
+          expect(result.country).toEqual(actor.country);
+          expect(result.gender).toEqual(actor.gender);
+          expect(result.photoUrl).toEqual(actor.photoUrl);
+        });
+      });
+  });
+
+  test('GET /api/v1/actor returns empty array if no actors are found', async () => {
+    const user = await mockUser();
+    const token = await mockAuthorizationFor(user)(app);
+
+    return request(app)
+      .get('/api/v1/actor')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200, []);
+  });
+
+  test('GET /api/v1/actor returns 401 if not authorized', async () =>
+    request(app)
+      .get('/api/v1/actor')
+      .expect(401, { error: { status: 401, message: 'Unauthorized' } })
+  );
+});

--- a/src/api/actor/effects/getActorList.effect.ts
+++ b/src/api/actor/effects/getActorList.effect.ts
@@ -1,0 +1,9 @@
+import { Effect } from '@marblejs/core';
+import { map, mergeMap } from 'rxjs/operators';
+import { ActorDao } from '../model/actor.dao';
+
+export const getActorListEffect$: Effect = req$ =>
+  req$.pipe(
+    mergeMap(ActorDao.findAll),
+    map(actors => ({ body: actors }))
+  );

--- a/src/api/actor/index.ts
+++ b/src/api/actor/index.ts
@@ -1,0 +1,19 @@
+import { combineRoutes, EffectFactory } from '@marblejs/core';
+import { authorize$ } from '../auth/middlewares/auth.middleware';
+import { getActorListEffect$ } from './effects/getActorList.effect';
+import { getActorEffect$ } from './effects/getActor.effect';
+
+const getActorList$ = EffectFactory
+  .matchPath('/')
+  .matchType('GET')
+  .use(getActorListEffect$);
+
+const getActor$ = EffectFactory
+  .matchPath('/:id')
+  .matchType('GET')
+  .use(getActorEffect$);
+
+export const actor$ = combineRoutes('/actor', {
+  effects: [getActorList$, getActor$],
+  middlewares: [authorize$],
+});

--- a/src/api/actor/model/actor.dao.spec.ts
+++ b/src/api/actor/model/actor.dao.spec.ts
@@ -1,0 +1,72 @@
+import { ActorDao } from './actor.dao';
+import { mockActor } from '../../../tests/actor.mock';
+
+describe('Actor DAO', () => {
+  test('#findAll finds all actors', async (done) => {
+    // given
+    const actors = [await mockActor(), await mockActor()];
+
+    // when
+    const result$ = ActorDao.findAll();
+
+    // then
+    result$.subscribe(result => {
+      result.forEach((item, i) => {
+        const reference = actors[i];
+        expect(item._id).toEqual(reference._id);
+        expect(item.birthday).toEqual(reference.birthday);
+        expect(item.gender).toEqual(reference.gender);
+        expect(item.name).toEqual(reference.name);
+        expect(item.birthday).toEqual(reference.birthday);
+        expect(item.deathday).toEqual(reference.deathday);
+        expect(item.imdbId).toEqual(reference.imdbId);
+        expect(item.photoUrl).toEqual(reference.photoUrl);
+        done();
+      });
+    });
+  });
+
+  test('#findById finds actor by _id', async (done) => {
+    // given
+    const actors = [await mockActor(), await mockActor()];
+    const targetUser = actors[0];
+
+    // when
+    const result$ = ActorDao.findById(targetUser._id);
+
+    // then
+    result$.subscribe(item => {
+      expect(item._id).toEqual(targetUser._id);
+      expect(item.birthday).toEqual(targetUser.birthday);
+      expect(item.gender).toEqual(targetUser.gender);
+      expect(item.name).toEqual(targetUser.name);
+      expect(item.birthday).toEqual(targetUser.birthday);
+      expect(item.deathday).toEqual(targetUser.deathday);
+      expect(item.imdbId).toEqual(targetUser.imdbId);
+      expect(item.photoUrl).toEqual(targetUser.photoUrl);
+      done();
+    });
+  });
+
+  test('#findOneByImdbID finds actor by "imdb" identifier', async (done) => {
+    // given
+    const actors = [await mockActor(), await mockActor()];
+    const targetUser = actors[0];
+
+    // when
+    const result$ = ActorDao.findOneByImdbID(targetUser.imdbId);
+
+    // then
+    result$.subscribe(item => {
+      expect(item._id).toEqual(targetUser._id);
+      expect(item.birthday).toEqual(targetUser.birthday);
+      expect(item.gender).toEqual(targetUser.gender);
+      expect(item.name).toEqual(targetUser.name);
+      expect(item.birthday).toEqual(targetUser.birthday);
+      expect(item.deathday).toEqual(targetUser.deathday);
+      expect(item.imdbId).toEqual(targetUser.imdbId);
+      expect(item.photoUrl).toEqual(targetUser.photoUrl);
+      done();
+    });
+  });
+});

--- a/src/api/actor/model/actor.dao.ts
+++ b/src/api/actor/model/actor.dao.ts
@@ -1,0 +1,18 @@
+import { from } from 'rxjs';
+import { Actor } from './actor.model';
+
+export namespace ActorDao {
+  export const model = new Actor().getModelForClass(Actor);
+
+  export const findAll = () => from(
+    model.find().exec()
+  );
+
+  export const findById = (id: string) => from(
+    model.findById(id).exec()
+  );
+
+  export const findOneByImdbID = (imdbId: string) => from(
+    model.findOne({ imdbId }).exec()
+  );
+}

--- a/src/api/actor/model/actor.model.ts
+++ b/src/api/actor/model/actor.model.ts
@@ -1,0 +1,29 @@
+import { prop, Typegoose } from 'typegoose';
+
+export enum Gender {
+  MALE = 'male',
+  FEMALE = 'female',
+}
+
+export class Actor extends Typegoose {
+  @prop({ required: true, index: true })
+  imdbId?: string;
+
+  @prop({ required: true })
+  name?: string;
+
+  @prop({ required: true })
+  birthday?: string;
+
+  @prop({ required: true })
+  country?: string;
+
+  @prop()
+  deathday?: string;
+
+  @prop({ required: true, enum: Gender })
+  gender?: Gender;
+
+  @prop()
+  photoUrl?: string;
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -3,6 +3,7 @@ import { versionEffect$ } from './common/effects/version.effect';
 import { notFoundEffect$ } from './common/effects/notFound.effect';
 import { auth$ } from './auth';
 import { user$ } from './user';
+import { actor$ } from './actor';
 
 const root$ = EffectFactory
   .matchPath('/')
@@ -16,5 +17,5 @@ const notFound$ = EffectFactory
 
 export const api$ = combineRoutes(
   '/api/v1',
-  [root$, auth$, user$, notFound$],
+  [root$, auth$, user$, actor$, notFound$],
 );

--- a/src/api/user/effects/getMe.effect.spec.ts
+++ b/src/api/user/effects/getMe.effect.spec.ts
@@ -31,7 +31,7 @@ describe('getMeEffect$', () => {
       .expect(401, { error: { status: 401, message: 'Unauthorized' } })
   );
 
-  test('GET /api/v1/user/me return 404 if user is not found', async () => {
+  test('GET /api/v1/user/me returns 404 if user is not found', async () => {
     const user = await mockUser();
     const token = await mockAuthorizationFor(user)(app);
 

--- a/src/seed/actors.generator.ts
+++ b/src/seed/actors.generator.ts
@@ -1,0 +1,103 @@
+import { generateCollectionFromModel } from './generator';
+import { Actor, Gender } from '../api/actor/model/actor.model';
+
+const actors = [
+  {
+    imdbId: 'nm0000093',
+    name: 'Brad Pitt',
+    birthday: new Date('1963-12-18'),
+    country: 'USA',
+    gender: Gender.MALE,
+    photoUrl: '@TODO',
+  },
+  {
+    imdbId: 'nm0001401',
+    name: 'Angelina Jolie',
+    birthday: new Date('1975-06-04'),
+    country: 'USA',
+    gender: Gender.FEMALE,
+    photoUrl: '@TODO',
+  },
+  {
+    imdbId: 'nm0000375',
+    name: 'Robert Downey Jr.',
+    birthday: new Date('1965-04-04'),
+    country: 'USA',
+    gender: Gender.MALE,
+    photoUrl: '@TODO',
+  },
+  {
+    imdbId: 'nm0000569',
+    name: 'Gwyneth Paltrow',
+    birthday: new Date('1972-09-27'),
+    country: 'USA',
+    gender: Gender.FEMALE,
+    photoUrl: '@TODO',
+  },
+  {
+    imdbId: 'nm1165110',
+    name: 'Chris Hemsworth',
+    birthday: new Date('1983-08-11'),
+    country: 'Australia',
+    gender: Gender.MALE,
+    photoUrl: '@TODO',
+  },
+  {
+    imdbId: 'nm0262635',
+    name: 'Chris Evans',
+    birthday: new Date('1981-06-13'),
+    country: 'USA',
+    gender: Gender.MALE,
+    photoUrl: '@TODO',
+  },
+  {
+    imdbId: 'nm0749263',
+    name: 'Mark Ruffalo',
+    birthday: new Date('1967-11-22'),
+    country: 'USA',
+    gender: Gender.MALE,
+    photoUrl: '@TODO',
+  },
+  {
+    imdbId: 'nm1130627',
+    name: 'Cobie Smulders',
+    birthday: new Date('1982-04-3'),
+    country: 'Canada',
+    gender: Gender.FEMALE,
+    photoUrl: '@TODO',
+  },
+  {
+    imdbId: 'nm0000168',
+    name: 'Samuel L. Jackson',
+    birthday: new Date('1948-12-21'),
+    country: 'USA',
+    gender: Gender.MALE,
+    photoUrl: '@TODO',
+  },
+  {
+    imdbId: 'nm0910607',
+    name: 'Christoph Waltz',
+    birthday: new Date('1956-10-04'),
+    country: 'Austria',
+    gender: Gender.MALE,
+    photoUrl: '@TODO',
+  },
+  {
+    imdbId: 'nm0004937',
+    name: 'Jamie Foxx',
+    birthday: new Date('1967-12-13'),
+    country: 'USA',
+    gender: Gender.MALE,
+    photoUrl: '@TODO',
+  },
+  {
+    imdbId: 'nm0000235',
+    name: 'Uma Thurman',
+    birthday: new Date('1970-04-29'),
+    country: 'USA',
+    gender: Gender.FEMALE,
+    photoUrl: '@TODO',
+  },
+];
+
+export const actorsGenerator = generateCollectionFromModel(Actor)(actors);

--- a/src/seed/index.ts
+++ b/src/seed/index.ts
@@ -1,9 +1,11 @@
 import { Database } from '../connection/database';
 import { usersGenerator } from './users.generator';
+import { actorsGenerator } from './actors.generator';
 
 const REGISTERED_GENERATORS = [
-  // @TODO: add movies/actors generators
+  // @TODO: add movies generators
   usersGenerator,
+  actorsGenerator,
 ];
 
 const seed = async () => {

--- a/src/seed/spec/index.spec.ts
+++ b/src/seed/spec/index.spec.ts
@@ -1,11 +1,16 @@
 import { Database } from '../../connection/database';
 
 let usersGeneratorModule;
+let actorsGeneratorModule;
 
 beforeEach(() => {
   jest.unmock('../users.generator');
   usersGeneratorModule = require('../users.generator');
   usersGeneratorModule.usersGenerator = jest.fn();
+
+  jest.unmock('../actors.generator');
+  actorsGeneratorModule = require('../actors.generator');
+  actorsGeneratorModule.actorsGenerator = jest.fn();
 });
 
 test('#seed seeds database with registered generators', done => {
@@ -21,6 +26,7 @@ test('#seed seeds database with registered generators', done => {
     expect(Database.connect).toHaveBeenCalled();
     expect(Database.drop).toHaveBeenCalled();
     expect(usersGeneratorModule.usersGenerator).toHaveBeenCalled();
+    expect(actorsGeneratorModule.actorsGenerator).toHaveBeenCalled();
     expect(Database.disconnect).toHaveBeenCalled();
     done();
   });

--- a/src/tests/actor.mock.ts
+++ b/src/tests/actor.mock.ts
@@ -1,0 +1,13 @@
+import * as faker from 'faker';
+import { ActorDao } from '../api/actor/model/actor.dao';
+import { Gender } from '../api/actor/model/actor.model';
+
+export const mockActor = async () =>
+  ActorDao.model.create({
+    imdbId: faker.random.uuid(),
+    name: faker.name.firstName() + ' ' + faker.name.lastName(),
+    birthday: faker.date.past(),
+    country: faker.address.country(),
+    gender: faker.random.arrayElement([Gender.FEMALE, Gender.MALE]),
+    photoUrl: faker.random.word(),
+  });


### PR DESCRIPTION
## Whats new?
- `GET /api/v1/actor` - list all actors
- `GET /api/v1/actor/:id` - get single actor by "imdb" ID
- seed database with mocked-up actors data

## TODO
- generate seed data for movies and add relation `movie 👉 actors`
- endpoint for listing all movies and single movie
- create `photoUrl`s for actors and expose them via dedicated assets endpoint