### PR TITLE
feat: collection queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@marblejs/middleware-jwt": "^1.1.0",
     "@marblejs/middleware-logger": "^1.1.0",
     "@types/faker": "^4.1.4",
+    "@types/joi": "^13.6.0",
     "@types/mongoose": "^5.2.12",
     "@types/node": "^10.1.2",
     "@types/uuid": "^3.4.4",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "test": "if-env TRAVIS=true && jest --expand --forceExit --coverage || jest --expand --coverage",
     "test:watch": "jest --expand --onlyChanged --watch",
     "docker": "docker-compose -f .docker/docker-compose.yml up --build -d",
-    "doc": "aglio -i src/api/index.apib -o dist/docs.html -t onlicar --theme-template triple",
-    "doc:watch": "aglio -i src/api/index.apib -o dist/docs.html -t onlicar --theme-template triple -s -p 3001",
+    "doc": "aglio -i src/api/index.apib -o dist/docs.html -t flatly --theme-template triple",
+    "doc:watch": "aglio -i src/api/index.apib -o dist/docs.html -t flatly --theme-template triple -s -p 3001",
     "db:seed": "yarn ts-node src/seed/index.ts"
   },
   "private": true,

--- a/src/api/actor/effects/getActorList.effect.ts
+++ b/src/api/actor/effects/getActorList.effect.ts
@@ -1,12 +1,18 @@
-import { Effect } from '@marblejs/core';
+import { Effect, use } from '@marblejs/core';
 import { of } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
-import { ActorDao } from '../model/actor.dao';
+import { ActorDao, SORTING_FIELDS } from '../model/actor.dao';
 import { applyHostnameForCollection } from '../model/actor.helpers';
+import { collectionQueryValidator$ } from '../../common/middlewares/collectionQuery.validator';
+import { CollectionQuery } from '../../common/helpers/collectionQuery.helper';
+
+type Query = CollectionQuery;
 
 export const getActorListEffect$: Effect = req$ =>
   req$.pipe(
+    use(collectionQueryValidator$({ sortBy: SORTING_FIELDS})),
     mergeMap(req => of(req).pipe(
+      map(req => req.query as Query),
       mergeMap(ActorDao.findAll),
       map(applyHostnameForCollection(req)),
       map(actors => ({ body: actors })),

--- a/src/api/actor/index.apib
+++ b/src/api/actor/index.apib
@@ -1,10 +1,37 @@
 # Group Actors
 
-## Actor list [/api/v1/actor]
+## Actor list [/api/v1/actor{?limit,page,sortBy,sortDir}]
 
 ### Get all actors [GET]
 
 Retrieve all actors
+
++ Parameters
+    + limit (number, optional) - set page limit
+
+        + Default: `0`
+
+    + page (number, optional) - set current page
+
+        + Default: `1`
+
+    + sortBy (enum, optional) - sort by given field
+
+        + Default: `_id`
+
+        + Members
+            + `_id`
+            + 'name'
+            + 'country'
+            + 'gender'
+
+    + sortDir (enum, optional) - set sorting direction (ascending/descending)
+
+        + Default: `1`
+
+        + Members
+            + `-1`
+            + `1`
 
 + Request
 

--- a/src/api/actor/model/actor.dao.spec.ts
+++ b/src/api/actor/model/actor.dao.spec.ts
@@ -1,13 +1,15 @@
 import { ActorDao } from './actor.dao';
 import { mockActor } from '../../../tests/actor.mock';
+import { SortDir } from '../../common/helpers/collectionQuery.helper';
 
 describe('Actor DAO', () => {
   test('#findAll finds all actors', async (done) => {
     // given
     const actors = [await mockActor(), await mockActor()];
+    const defaultQuery = { sortBy: '_id', limit: 0, sortDir: SortDir.ASC, page: 1 };
 
     // when
-    const result$ = ActorDao.findAll();
+    const result$ = ActorDao.findAll(defaultQuery);
 
     // then
     result$.subscribe(result => {

--- a/src/api/actor/model/actor.dao.ts
+++ b/src/api/actor/model/actor.dao.ts
@@ -2,7 +2,7 @@ import { from } from 'rxjs';
 import { Actor } from './actor.model';
 import { applyCollectionQuery, CollectionQuery } from '../../common/helpers/collectionQuery.helper';
 
-export const SORTING_FIELDS = ['name', 'country', 'gender'];
+export const SORTING_FIELDS = ['_id', 'name', 'country', 'gender'];
 
 export namespace ActorDao {
   export const model = new Actor().getModelForClass(Actor);

--- a/src/api/actor/model/actor.dao.ts
+++ b/src/api/actor/model/actor.dao.ts
@@ -1,11 +1,14 @@
 import { from } from 'rxjs';
 import { Actor } from './actor.model';
+import { applyCollectionQuery, CollectionQuery } from '../../common/helpers/collectionQuery.helper';
+
+export const SORTING_FIELDS = ['name', 'country', 'gender'];
 
 export namespace ActorDao {
   export const model = new Actor().getModelForClass(Actor);
 
-  export const findAll = () => from(
-    model.find().exec()
+  export const findAll = (query: CollectionQuery) => from(
+    applyCollectionQuery(query)(model.find()).exec()
   );
 
   export const findById = (id: string) => from(

--- a/src/api/auth/index.apib
+++ b/src/api/auth/index.apib
@@ -16,7 +16,7 @@ The client must send this token in the `Authorization` header when making reques
 
 ### Authorize user [POST]
 
-Log in user the system by given credentials
+Log in user into the system by given credentials
 
 + Request (application/json)
 

--- a/src/api/auth/index.apib
+++ b/src/api/auth/index.apib
@@ -16,6 +16,8 @@ The client must send this token in the `Authorization` header when making reques
 
 ### Authorize user [POST]
 
+Log in user the system by given credentials
+
 + Request (application/json)
 
         {

--- a/src/api/common/helpers/collectionQuery.helper.spec.ts
+++ b/src/api/common/helpers/collectionQuery.helper.spec.ts
@@ -1,0 +1,56 @@
+import { mockMovie } from '../../../tests/movie.mock';
+import { MovieDao } from '../../movie/model/movie.dao';
+import { applyCollectionQuery, SortDir } from './collectionQuery.helper';
+
+describe('#applyCollectionQuery', () => {
+  beforeEach(async () => {
+    await mockMovie();
+    await mockMovie();
+    await mockMovie();
+    await mockMovie();
+  });
+
+  test('sorts query by given field ascending', async () => {
+    // given
+    const query = { sortBy: 'metascore', limit: 0, sortDir: SortDir.ASC, page: 1 };
+    const document = MovieDao.model.find();
+
+    // when
+    const result = await applyCollectionQuery(query)(document).exec();
+
+    // then
+    expect(result[0].metascore! <= result[1].metascore!).toBe(true);
+    expect(result[1].metascore! <= result[2].metascore!).toBe(true);
+    expect(result[2].metascore! <= result[3].metascore!).toBe(true);
+  });
+
+  test('sorts query by given field descending', async () => {
+    // given
+    const query = { sortBy: 'metascore', limit: 0, sortDir: SortDir.DESC, page: 1 };
+    const document = MovieDao.model.find();
+
+    // when
+    const result = await applyCollectionQuery(query)(document).exec();
+
+    // then
+    expect(result[0].metascore! >= result[1].metascore!).toBe(true);
+    expect(result[1].metascore! >= result[2].metascore!).toBe(true);
+    expect(result[2].metascore! >= result[3].metascore!).toBe(true);
+  });
+
+  test('paginates query by given limit and page number', async () => {
+    // given
+    const query = { sortBy: '_id', limit: 2, sortDir: SortDir.ASC };
+    const document = MovieDao.model.find();
+
+    // when
+    const page1 = await applyCollectionQuery({ ...query, page: 1 })(document).exec();
+    const page2 = await applyCollectionQuery({ ...query, page: 2 })(document).exec();
+
+    // then
+    expect(page1.length).toBe(2);
+    expect(page2.length).toBe(2);
+    expect(page1[0].imdbId).not.toEqual(page2[0].imdbId);
+    expect(page1[1].imdbId).not.toEqual(page2[1].imdbId);
+  });
+});

--- a/src/api/common/helpers/collectionQuery.helper.ts
+++ b/src/api/common/helpers/collectionQuery.helper.ts
@@ -1,0 +1,18 @@
+import { Document, DocumentQuery } from 'mongoose';
+
+export interface CollectionQuery extends Record<string, any> {
+  sortBy: string;
+  sortDir: SortDir;
+  limit: number;
+  page: number;
+}
+
+export enum SortDir {
+  ASC = 1,
+  DESC = -1,
+}
+
+export const applyCollectionQuery = (query: CollectionQuery) => <T, U extends Document>(doc: DocumentQuery<T, U>) =>
+  doc.limit(query.limit)
+    .skip((query.page - 1) * query.limit)
+    .sort({ [query.sortBy]: query.sortDir });

--- a/src/api/common/middlewares/collectionQuery.validator.ts
+++ b/src/api/common/middlewares/collectionQuery.validator.ts
@@ -1,0 +1,15 @@
+import { validator$, Joi } from '@marblejs/middleware-joi';
+import { SortDir } from '../helpers/collectionQuery.helper';
+
+export interface CollectionQueryValidatorOpts {
+  sortBy: string[];
+}
+
+export const collectionQueryValidator$ = (opts: CollectionQueryValidatorOpts) => validator$({
+  query: Joi.object({
+    sortBy: Joi.string().valid(opts.sortBy).default('_id'),
+    sortDir: Joi.number().valid(SortDir.DESC, SortDir.ASC).default(SortDir.ASC),
+    limit: Joi.number().min(0),
+    page: Joi.number().min(1),
+  })
+});

--- a/src/api/index.apib
+++ b/src/api/index.apib
@@ -14,9 +14,9 @@ http://marblejs-example.herokuapp.com
 
 ## Version [/api/v1]
 
-Retrieve information about API availability
-
 ### Get version [GET]
+
+Retrieve information about API availability
 
 + Response 200 (text/plain)
 

--- a/src/api/movie/effects/getMovieList.effect.ts
+++ b/src/api/movie/effects/getMovieList.effect.ts
@@ -1,12 +1,18 @@
-import { Effect } from '@marblejs/core';
+import { Effect, use } from '@marblejs/core';
 import { of } from 'rxjs';
 import { mergeMap, map } from 'rxjs/operators';
-import { MovieDao } from '../model/movie.dao';
+import { MovieDao, SORTING_FIELDS } from '../model/movie.dao';
 import { applyHostnameForCollection } from '../../movie/model/movie.helpers';
+import { collectionQueryValidator$ } from '../../common/middlewares/collectionQuery.validator';
+import { CollectionQuery } from '../../common/helpers/collectionQuery.helper';
+
+type Query = CollectionQuery;
 
 export const getMovieListEffect$: Effect = req$ =>
   req$.pipe(
+    use(collectionQueryValidator$({ sortBy: SORTING_FIELDS})),
     mergeMap(req => of(req).pipe(
+      map(req => req.query as Query),
       mergeMap(MovieDao.findAll),
       map(applyHostnameForCollection(req)),
       map(movies => ({ body: movies })),

--- a/src/api/movie/index.apib
+++ b/src/api/movie/index.apib
@@ -1,10 +1,38 @@
 # Group Movies
 
-## Movie list [/api/v1/movie]
+## Movie list [/api/v1/movie{?limit,page,sortBy,sortDir}]
 
 ### Get all movies [GET]
 
 Retrieve all movies
+
++ Parameters
+    + limit (number, optional) - set page limit
+
+        + Default: `0`
+
+    + page (number, optional) - set current page
+
+        + Default: `1`
+
+    + sortBy (enum, optional) - sort by given field
+
+        + Default: `_id`
+
+        + Members
+            + `_id`
+            + 'title'
+            + 'director'
+            + 'year'
+            + `metascore`
+
+    + sortDir (enum, optional) - set sorting direction (ascending/descending)
+
+        + Default: `1`
+
+        + Members
+            + `-1`
+            + `1`
 
 + Request
 

--- a/src/api/movie/model/movie.dao.spec.ts
+++ b/src/api/movie/model/movie.dao.spec.ts
@@ -1,13 +1,15 @@
 import { MovieDao } from './movie.dao';
 import { mockMovie } from '../../../tests/movie.mock';
+import { SortDir } from '../../common/helpers/collectionQuery.helper';
 
 describe('Movie DAO', () => {
   test('#findAll finds all movies', async (done) => {
     // given
     const movies = [await mockMovie(), await mockMovie()];
+    const defaultQuery = { sortBy: '_id', limit: 0, sortDir: SortDir.ASC, page: 1 };
 
     // when
-    const result$ = MovieDao.findAll();
+    const result$ = MovieDao.findAll(defaultQuery);
 
     // then
     result$.subscribe(result => {

--- a/src/api/movie/model/movie.dao.ts
+++ b/src/api/movie/model/movie.dao.ts
@@ -2,7 +2,7 @@ import { from } from 'rxjs';
 import { Movie } from './movie.model';
 import { applyCollectionQuery, CollectionQuery } from '../../common/helpers/collectionQuery.helper';
 
-export const SORTING_FIELDS = ['title', 'director', 'year', 'metascore'];
+export const SORTING_FIELDS = ['_id', 'title', 'director', 'year', 'metascore'];
 
 export namespace MovieDao {
   export const model = new Movie().getModelForClass(Movie);

--- a/src/api/movie/model/movie.dao.ts
+++ b/src/api/movie/model/movie.dao.ts
@@ -1,11 +1,14 @@
 import { from } from 'rxjs';
 import { Movie } from './movie.model';
+import { applyCollectionQuery, CollectionQuery } from '../../common/helpers/collectionQuery.helper';
+
+export const SORTING_FIELDS = ['title', 'director', 'year', 'metascore'];
 
 export namespace MovieDao {
   export const model = new Movie().getModelForClass(Movie);
 
-  export const findAll = () => from(
-    model.find().exec()
+  export const findAll = (query: CollectionQuery) => from(
+    applyCollectionQuery(query)(model.find()).exec()
   );
 
   export const findById = (id: string) => from(

--- a/yarn.lock
+++ b/yarn.lock
@@ -75,6 +75,10 @@
   version "23.3.2"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.2.tgz#07b90f6adf75d42c34230c026a2529e56c249dbb"
 
+"@types/joi@^13.6.0":
+  version "13.6.0"
+  resolved "https://registry.yarnpkg.com/@types/joi/-/joi-13.6.0.tgz#69b289d18619efb298aed9a3efdc9ad286fb0c64"
+
 "@types/jsonwebtoken@^7.2.8":
   version "7.2.8"
   resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-7.2.8.tgz#8d199dab4ddb5bba3234f8311b804d2027af2b3a"


### PR DESCRIPTION
## Whats new?
- added collection queries for `movie` and `actor` entities
- supported queries: `page`, `limit`, `sortBy`, `sortDir`

## TODO
- more detailed integration tests for `actor` and `movie` endpoints, which will include queries testing
- update API doc blueprints with introduced queries support
